### PR TITLE
Fix syntax error in rofi template

### DIFF
--- a/dotfiles/.config/rofi/QARSlp.rasi
+++ b/dotfiles/.config/rofi/QARSlp.rasi
@@ -8,7 +8,7 @@
     color7: {color7};
     color8: {color8};
     active: {color2};
-    urgent;'ffcc00';
+    urgent: #ffcc00;
     active-background: {color2};
     active-foreground: {color6};
     normal-background: @background;


### PR DESCRIPTION
A syntax error in QARSlp.rasi template caused rofi invocations to fail. This commit fixes the error.